### PR TITLE
fix: prevent analytics error if no measurementId defined

### DIFF
--- a/app/analytics.ts
+++ b/app/analytics.ts
@@ -17,7 +17,7 @@ export const createFirebaseApp = () => {
     // Check that `window` is in scope for the analytics module!
     if (typeof window !== "undefined") {
       // Enable analytics. https://firebase.google.com/docs/analytics/get-started
-      if ("measurementId" in clientCredentials) {
+      if (clientCredentials.measurementId) {
         getAnalytics();
       }
     }


### PR DESCRIPTION
NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID 없으면 아래 에러 발생 방지

```
FirebaseError: Installations: Missing App configuration value: "projectId" (installations/missing-app-config-values).
```